### PR TITLE
Added typescript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   ],
   "license": "MIT",
   "main": "dist/vue-clickaway.common.js",
+  "types": "types/index.d.ts",
   "peerDependencies": {
     "vue": "^2.0.0"
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for vue-clickaway2 2.3
+// Project: https://github.com/silverspectro/vue-clickaway2
+// Definitions by: Khoa Nguyen <https://github.com/khoanguyen96>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.6
+import Vue, { ComponentOptions, DirectiveOptions } from 'vue';
+
+export const directive: DirectiveOptions;
+export const mixin: ComponentOptions<Vue> | typeof Vue;


### PR DESCRIPTION
Types are copy from vue-clickaway types in DefinitelyTyped: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/vue-clickaway/index.d.ts